### PR TITLE
Fix build error found in openSUSE's Open Build Service (OBS)

### DIFF
--- a/grub-core/commands/appendedsig/appendedsig.c
+++ b/grub-core/commands/appendedsig/appendedsig.c
@@ -679,7 +679,7 @@ grub_cmd_trusted_list (grub_command_t cmd __attribute__((unused)),
 
   for (cert = grub_db.keys; cert; cert = cert->next)
     {
-      grub_printf (N_("trusted certificate %d:\n"), cert_num);
+      grub_printf (N_("trusted certificate %" PRIuGRUB_SIZE ":\n"), cert_num);
       grub_printf (N_("\tserial: "));
 
       for (i = 0; i < cert->serial_len - 1; i++)
@@ -692,7 +692,7 @@ grub_cmd_trusted_list (grub_command_t cmd __attribute__((unused)),
 
   for (i = 0; i < grub_db.signature_entries; i++)
     {
-      grub_printf (N_("trusted binary hash %d:\n"), i+1);
+      grub_printf (N_("trusted binary hash %" PRIuGRUB_SIZE ":\n"), i+1);
       grub_printf (N_("\thash: "));
       grub_printhex (grub_db.signatures[i], grub_db.signature_size[i]);
     }
@@ -710,7 +710,7 @@ grub_cmd_distrusted_list (grub_command_t cmd __attribute__((unused)),
 
   for (cert = grub_dbx.keys; cert; cert = cert->next)
     {
-      grub_printf (N_("distrusted certificate %d:\n"), cert_num);
+      grub_printf (N_("distrusted certificate %" PRIuGRUB_SIZE ":\n"), cert_num);
       grub_printf (N_("\tserial: "));
 
       for (i = 0; i < cert->serial_len - 1; i++)
@@ -723,7 +723,7 @@ grub_cmd_distrusted_list (grub_command_t cmd __attribute__((unused)),
 
   for (i = 0; i < grub_dbx.signature_entries; i++)
     {
-      grub_printf (N_("distrusted certificate/binary hash %d:\n"), i+1);
+      grub_printf (N_("distrusted certificate/binary hash %" PRIuGRUB_SIZE ":\n"), i+1);
       grub_printf (N_("\thash: "));
       grub_printhex (grub_dbx.signatures[i], grub_dbx.signature_size[i]);
     }
@@ -824,7 +824,7 @@ grub_cmd_trusted_hash (grub_command_t cmd __attribute__((unused)), int argc, cha
 
   grub_file_close (hash_file);
 
-  grub_dprintf ("appendedsig", "adding a trusted binary hash %s\n with size of %u\n",
+  grub_dprintf ("appendedsig", "adding a trusted binary hash %s\n with size of %" PRIdGRUB_SSIZE "\n",
                 hash_data, hash_data_size);
 
   /* only accept SHA256, SHA384 and SHA512 binary hash */
@@ -874,7 +874,7 @@ grub_cmd_distrusted_cert (grub_command_t cmd __attribute__((unused)), int argc, 
 
   if (cert_num > grub_db.key_entries)
     return grub_error (GRUB_ERR_BAD_ARGUMENT,
-                       N_("trusted certificate number should not exceed %u"),
+                       N_("trusted certificate number should not exceed %" PRIuGRUB_SIZE),
                        grub_db.key_entries);
   else if (cert_num < grub_db.key_entries)
     return grub_error (GRUB_ERR_BAD_ARGUMENT,
@@ -949,7 +949,7 @@ grub_cmd_distrusted_hash (grub_extcmd_context_t ctxt, int argc, char **args)
   grub_file_close (hash_file);
 
   grub_dprintf ("appendedsig", "adding a distrusted certificate/binary hash %s\n"
-                " with size of %u\n", hash_data, hash_data_size);
+                " with size of %" PRIdGRUB_SSIZE "\n", hash_data, hash_data_size);
 
   if (ctxt->state[OPTION_BINARY_HASH].set)
     {

--- a/grub-core/commands/appendedsig/appendedsig.c
+++ b/grub-core/commands/appendedsig/appendedsig.c
@@ -485,7 +485,7 @@ grub_get_binary_hash (const grub_size_t binary_hash_size, const grub_uint8_t *da
     grub_memcpy (&guid, &GRUB_PKS_CERT_SHA512_GUID, GRUB_UUID_SIZE);
   else
     {
-      grub_dprintf ("appendedsig", "unsupported hash type (%d) and skipping binary hash\n",
+      grub_dprintf ("appendedsig", "unsupported hash type (%" PRIuGRUB_SIZE ") and skipping binary hash\n",
                     binary_hash_size);
       return GRUB_ERR_UNKNOWN_COMMAND;
     }

--- a/grub-core/commands/appendedsig/appendedsig.c
+++ b/grub-core/commands/appendedsig/appendedsig.c
@@ -1208,7 +1208,7 @@ grub_create_trusted_list (void)
         }
       else
         grub_printf ("Warning: unsupported signature data type and "
-                     "skipping trusted data (%d)\n", i + 1);
+                     "skipping trusted data (%" PRIuGRUB_SIZE ")\n", i + 1);
     }
 
   return GRUB_ERR_NONE;
@@ -1247,7 +1247,7 @@ grub_create_distrusted_list (void)
             }
           else
             grub_printf ("Warning: unsupported signature data type and "
-                         "skipping distrusted data (%d)\n", i + 1);
+                         "skipping distrusted data (%" PRIuGRUB_SIZE ")\n", i + 1);
         }
     }
 
@@ -1383,7 +1383,7 @@ GRUB_MOD_INIT (appendedsig)
           grub_error (rc, "static trusted list creation failed");
         }
       else
-        grub_printf ("appendedsig: the trusted list now has %u static keys\n",
+        grub_printf ("appendedsig: the trusted list now has %" PRIuGRUB_SIZE " static keys\n",
                      grub_db.key_entries);
     }
   else if (grub_use_platform_keystore && check_sigs == check_sigs_forced)
@@ -1412,8 +1412,8 @@ GRUB_MOD_INIT (appendedsig)
               grub_error (rc, "distrusted list creation failed");
             }
           else
-            grub_printf ("appendedsig: the trusted list now has %u keys.\n"
-                         "appendedsig: the distrusted list now has %u keys.\n",
+            grub_printf ("appendedsig: the trusted list now has %" PRIuGRUB_SIZE " keys.\n"
+                         "appendedsig: the distrusted list now has %" PRIuGRUB_SIZE " keys.\n",
                          grub_db.signature_entries + grub_db.key_entries,
                          grub_dbx.signature_entries);
         }

--- a/grub-core/kern/ieee1275/platform_keystore.c
+++ b/grub-core/kern/ieee1275/platform_keystore.c
@@ -349,7 +349,7 @@ grub_platform_keystore_init (void)
       /* DB */
       rc = grub_secure_boot_variables (0, DB, &grub_platform_keystore.db,
                                        &grub_platform_keystore.db_entries);
-      if (rc == PKS_OBJECT_NOT_FOUND)
+      if ((int)rc == PKS_OBJECT_NOT_FOUND)
         {
           rc = GRUB_ERR_NONE;
           /* DB variable won't be available by default in PKS, So, it will loads the Default Keys from ELF Note */
@@ -361,7 +361,7 @@ grub_platform_keystore_init (void)
           /* DBX */
           rc = grub_secure_boot_variables (0, DBX, &grub_platform_keystore.dbx,
                                            &grub_platform_keystore.dbx_entries);
-          if (rc == PKS_OBJECT_NOT_FOUND)
+          if ((int)rc == PKS_OBJECT_NOT_FOUND)
             {
               grub_printf ("Warning: dbx is not found!\n");
               rc = GRUB_ERR_NONE;


### PR DESCRIPTION
This resolves the build errors encountered in openSUSE's Open Build Service (OBS). The first issue occurs on the ppc64le target, while the second affects other CPU architectures.

PS. I used fixup commits in the hope that it will help to squash these changes into the relative commits.

1.
```
../../grub-core/kern/ieee1275/platform_keystore.c: In function 'grub_platform_keystore_init':
../../grub-core/kern/ieee1275/platform_keystore.c:352:14: error: comparison of integer expressions of different signedness: 'grub_err_t' and 'int' [-Werror=sign-compare]
  352 |       if (rc == PKS_OBJECT_NOT_FOUND)
      |              ^~
../../grub-core/kern/ieee1275/platform_keystore.c:364:18: error: comparison of integer expressions of different signedness: 'grub_err_t' and 'int' [-Werror=sign-compare]
  364 |           if (rc == PKS_OBJECT_NOT_FOUND)
      |                  ^~
cc1: all warnings being treated as errors
make[3]: *** [Makefile:44102: kern/ieee1275/kernel_exec-platform_keystore.o] Error 1
```

2.
```
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c: In function ‘grub_get_binary_hash’:
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c:501:36: error: format ‘%d’ expects argument of type ‘int’, but argument 5 has type ‘grub_size_t’ {aka ‘long unsigned int’} [-Werror=format=]
[   72s]   501 |       grub_dprintf ("appendedsig", "unsupported hash type (%d) and skipping binary hash\n",
[   72s]       |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[   72s]   502 |                     binary_hash_size);
[   72s]       |                     ~~~~~~~~~~~~~~~~
[   72s]       |                     |
[   72s]       |                     grub_size_t {aka long unsigned int}
[   72s] ../../include/grub/misc.h:38:88: note: in definition of macro ‘grub_dprintf’
[   72s]    38 | #define grub_dprintf(condition, ...) grub_real_dprintf(GRUB_FILE, __LINE__, condition, __VA_ARGS__)
[   72s]       |                                                                                        ^~~~~~~~~~~
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c:501:61: note: format string is defined here
[   72s]   501 |       grub_dprintf ("appendedsig", "unsupported hash type (%d) and skipping binary hash\n",
[   72s]       |                                                            ~^
[   72s]       |                                                             |
[   72s]       |                                                             int
[   72s]       |                                                            %ld
[   72s] In file included from ../../include/grub/misc.h:27:
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c: In function ‘grub_cmd_trusted_list’:
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c:696:23: error: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘grub_size_t’ {aka ‘long unsigned int’} [-Werror=format=]
[   72s]   696 |       grub_printf (N_("trusted certificate %d:\n"), cert_num);
[   72s]       |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~
[   72s] ../../include/grub/i18n.h:66:17: note: in definition of macro ‘N_’
[   72s]    66 | #define N_(str) str
[   72s]       |                 ^~~
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c:696:45: note: format string is defined here
[   72s]   696 |       grub_printf (N_("trusted certificate %d:\n"), cert_num);
[   72s]       |                                            ~^
[   72s]       |                                             |
[   72s]       |                                             int
[   72s]       |                                            %ld
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c:710:23: error: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘grub_size_t’ {aka ‘long unsigned int’} [-Werror=format=]
[   72s]   710 |       grub_printf (N_("trusted binary hash %d:\n"), i+1);
[   72s]       |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~
[   72s] ../../include/grub/i18n.h:66:17: note: in definition of macro ‘N_’
[   72s]    66 | #define N_(str) str
[   72s]       |                 ^~~
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c:710:45: note: format string is defined here
[   72s]   710 |       grub_printf (N_("trusted binary hash %d:\n"), i+1);
[   72s]       |                                            ~^
[   72s]       |                                             |
[   72s]       |                                             int
[   72s]       |                                            %ld
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c: In function ‘grub_cmd_distrusted_list’:
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c:728:23: error: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘grub_size_t’ {aka ‘long unsigned int’} [-Werror=format=]
[   72s]   728 |       grub_printf (N_("distrusted certificate %d:\n"), cert_num);
[   72s]       |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[   72s] ../../include/grub/i18n.h:66:17: note: in definition of macro ‘N_’
[   72s]    66 | #define N_(str) str
[   72s]       |                 ^~~
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c:728:48: note: format string is defined here
[   72s]   728 |       grub_printf (N_("distrusted certificate %d:\n"), cert_num);
[   72s]       |                                               ~^
[   72s]       |                                                |
[   72s]       |                                                int
[   72s]       |                                               %ld
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c:741:23: error: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘grub_size_t’ {aka ‘long unsigned int’} [-Werror=format=]
[   72s]   741 |       grub_printf (N_("distrusted certificate/binary hash %d:\n"), i+1);
[   72s]       |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[   72s] ../../include/grub/i18n.h:66:17: note: in definition of macro ‘N_’
[   72s]    66 | #define N_(str) str
[   72s]       |                 ^~~
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c:741:60: note: format string is defined here
[   72s]   741 |       grub_printf (N_("distrusted certificate/binary hash %d:\n"), i+1);
[   72s]       |                                                           ~^
[   72s]       |                                                            |
[   72s]       |                                                            int
[   72s]       |                                                           %ld
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c: In function ‘grub_cmd_trusted_hash’:
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c:842:32: error: format ‘%u’ expects argument of type ‘unsigned int’, but argument 6 has type ‘grub_ssize_t’ {aka ‘long int’} [-Werror=format=]
[   72s]   842 |   grub_dprintf ("appendedsig", "adding a trusted binary hash %s\n with size of %u\n",
[   72s]       |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[   72s]   843 |                 hash_data, hash_data_size);
[   72s]       |                            ~~~~~~~~~~~~~~
[   72s]       |                            |
[   72s]       |                            grub_ssize_t {aka long int}
[   72s] ../../include/grub/misc.h:38:88: note: in definition of macro ‘grub_dprintf’
[   72s]    38 | #define grub_dprintf(condition, ...) grub_real_dprintf(GRUB_FILE, __LINE__, condition, __VA_ARGS__)
[   72s]       |                                                                                        ^~~~~~~~~~~
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c:842:81: note: format string is defined here
[   72s]   842 |   grub_dprintf ("appendedsig", "adding a trusted binary hash %s\n with size of %u\n",
[   72s]       |                                                                                ~^
[   72s]       |                                                                                 |
[   72s]       |                                                                                 unsigned int
[   72s]       |                                                                                %lu
[   72s] In file included from ../../include/grub/misc.h:26:
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c: In function ‘grub_cmd_distrusted_cert’:
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c:892:27: error: format ‘%u’ expects argument of type ‘unsigned int’, but argument 5 has type ‘grub_size_t’ {aka ‘long unsigned int’} [-Werror=format=]
[   72s]   892 |                        N_("trusted certificate number should not exceed %u"),
[   72s]       |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[   72s] ../../include/grub/err.h:92:68: note: in definition of macro ‘grub_error’
[   72s]    92 | #define grub_error(n, fmt, ...) grub_error (n, __FILE__, __LINE__, fmt, ##__VA_ARGS__)
[   72s]       |                                                                    ^~~
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c:892:24: note: in expansion of macro ‘N_’
[   72s]   892 |                        N_("trusted certificate number should not exceed %u"),
[   72s]       |                        ^~
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c:892:74: note: format string is defined here
[   72s]   892 |                        N_("trusted certificate number should not exceed %u"),
[   72s]       |                                                                         ~^
[   72s]       |                                                                          |
[   72s]       |                                                                          unsigned int
[   72s]       |                                                                         %lu
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c: In function ‘grub_cmd_distrusted_hash’:
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c:966:32: error: format ‘%u’ expects argument of type ‘unsigned int’, but argument 6 has type ‘grub_ssize_t’ {aka ‘long int’} [-Werror=format=]
[   72s]   966 |   grub_dprintf ("appendedsig", "adding a distrusted certificate/binary hash %s\n"
[   72s]       |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[   72s]   967 |                 " with size of %u\n", hash_data, hash_data_size);
[   72s]       |                                                  ~~~~~~~~~~~~~~
[   72s]       |                                                  |
[   72s]       |                                                  grub_ssize_t {aka long int}
[   72s] ../../include/grub/misc.h:38:88: note: in definition of macro ‘grub_dprintf’
[   72s]    38 | #define grub_dprintf(condition, ...) grub_real_dprintf(GRUB_FILE, __LINE__, condition, __VA_ARGS__)
[   72s]       |                                                                                        ^~~~~~~~~~~
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c: In function ‘grub_create_trusted_list’:
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c:1229:22: error: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘grub_size_t’ {aka ‘long unsigned int’} [-Werror=format=]
[   72s]  1229 |         grub_printf ("Warning: unsupported signature data type and "
[   72s]       |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[   72s]  1230 |                      "skipping trusted data (%d)\n", i + 1);
[   72s]       |                                                      ~~~~~
[   72s]       |                                                        |
[   72s]       |                                                        grub_size_t {aka long unsigned int}
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c:1230:47: note: format string is defined here
[   72s]  1230 |                      "skipping trusted data (%d)\n", i + 1);
[   72s]       |                                              ~^
[   72s]       |                                               |
[   72s]       |                                               int
[   72s]       |                                              %ld
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c: In function ‘grub_create_distrusted_list’:
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c:1268:26: error: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘grub_size_t’ {aka ‘long unsigned int’} [-Werror=format=]
[   72s]  1268 |             grub_printf ("Warning: unsupported signature data type and "
[   72s]       |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[   72s]  1269 |                          "skipping distrusted data (%d)\n", i + 1);
[   72s]       |                                                             ~~~~~
[   72s]       |                                                               |
[   72s]       |                                                               grub_size_t {aka long unsigned int}
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c:1269:54: note: format string is defined here
[   72s]  1269 |                          "skipping distrusted data (%d)\n", i + 1);
[   72s]       |                                                     ~^
[   72s]       |                                                      |
[   72s]       |                                                      int
[   72s]       |                                                     %ld
[   72s] mv -f commands/appendedsig/.deps-core/appendedsig_module-asn1util.Tpo commands/appendedsig/.deps-core/appendedsig_module-asn1util.Po
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c: In function ‘grub_mod_init’:
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c:1406:62: error: format ‘%u’ expects argument of type ‘unsigned int’, but argument 2 has type ‘grub_size_t’ {aka ‘long unsigned int’} [-Werror=format=]
[   72s]  1406 |         grub_printf ("appendedsig: the trusted list now has %u static keys\n",
[   72s]       |                                                             ~^
[   72s]       |                                                              |
[   72s]       |                                                              unsigned int
[   72s]       |                                                             %lu
[   72s]  1407 |                      grub_db.key_entries);
[   72s]       |                      ~~~~~~~~~~~~~~~~~~~
[   72s]       |                             |
[   72s]       |                             grub_size_t {aka long unsigned int}
[   72s] gcc -DHAVE_CONFIG_H -I. -I../../grub-core -I..  -Wall -W  -DGRUB_MACHINE_EMU=1 -DGRUB_MACHINE=X86_64_EMU -I../../include -I../include -DGRUB_FILE=\"commands/appendedsig/pkix_asn1_tab.c\" -I. -I../../grub-core -I.. -I../.. -I../../include -I../include -I../../grub-core/lib/libgcrypt-grub/src/   -I../../grub-core/lib/posix_wrap  -D_FILE_OFFSET_BITS=64 -std=gnu99 -fno-common -Os -Wall -W -Wshadow -Wpointer-arith -Wundef -Wchar-subscripts -Wcomment -Wdeprecated-declarations -Wdisabled-optimization -Wdiv-by-zero -Wfloat-equal -Wformat-extra-args -Wformat-security -Wformat-y2k -Wimplicit -Wimplicit-function-declaration -Wimplicit-int -Wmain -Wmissing-braces -Wmissing-format-attribute -Wmultichar -Wparentheses -Wreturn-type -Wsequence-point -Wshadow -Wsign-compare -Wswitch -Wtrigraphs -Wunknown-pragmas -Wunused -Wunused-function -Wunused-label -Wunused-parameter -Wunused-value  -Wunused-variable -Wwrite-strings -Wnested-externs -Wstrict-prototypes -g -Wredundant-decls -Wmissing-prototypes -Wmissing-declarations  -Wextra -Wattributes -Wendif-labels -Winit-self -Wint-to-pointer-cast -Winvalid-pch -Wmissing-field-initializers -Wnonnull -Woverflow -Wvla -Wpointer-to-int-cast -Wstrict-aliasing -Wvariadic-macros -Wvolatile-register-var -Wpointer-sign -Wmissing-include-dirs -Wmissing-prototypes -Wmissing-declarations -Wformat=2 -freg-struct-return -Wa,-mx86-used-note=no -fno-omit-frame-pointer -fno-dwarf2-cfi-asm -mno-stack-arg-probe -fno-asynchronous-unwind-tables -fno-unwind-tables -fno-ident -mcmodel=large -fno-PIE -fno-pie -fno-stack-protector -Wtrampolines -Werror    -ffreestanding -fno-builtin  -fno-strict-aliasing -fno-inline-functions-called-once  -MT commands/appendedsig/appendedsig_module-pkix_asn1_tab.o -MD -MP -MF commands/appendedsig/.deps-core/appendedsig_module-pkix_asn1_tab.Tpo -c -o commands/appendedsig/appendedsig_module-pkix_asn1_tab.o `test -f 'commands/appendedsig/pkix_asn1_tab.c' || echo '../../grub-core/'`commands/appendedsig/pkix_asn1_tab.c
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c:1435:66: error: format ‘%u’ expects argument of type ‘unsigned int’, but argument 2 has type ‘grub_size_t’ {aka ‘long unsigned int’} [-Werror=format=]
[   72s]  1435 |             grub_printf ("appendedsig: the trusted list now has %u keys.\n"
[   72s]       |                                                                 ~^
[   72s]       |                                                                  |
[   72s]       |                                                                  unsigned int
[   72s]       |                                                                 %lu
[   72s]  1436 |                          "appendedsig: the distrusted list now has %u keys.\n",
[   72s]  1437 |                          grub_db.signature_entries + grub_db.key_entries,
[   72s]       |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[   72s]       |                                                    |
[   72s]       |                                                    grub_size_t {aka long unsigned int}
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c:1435:26: error: format ‘%u’ expects argument of type ‘unsigned int’, but argument 3 has type ‘grub_size_t’ {aka ‘long unsigned int’} [-Werror=format=]
[   72s]  1435 |             grub_printf ("appendedsig: the trusted list now has %u keys.\n"
[   72s]       |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[   72s] ......
[   72s]  1438 |                          grub_dbx.signature_entries);
[   72s]       |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~
[   72s]       |                                  |
[   72s]       |                                  grub_size_t {aka long unsigned int}
[   72s] ../../grub-core/commands/appendedsig/appendedsig.c:1436:69: note: format string is defined here
[   72s]  1436 |                          "appendedsig: the distrusted list now has %u keys.\n",
[   72s]       |                                                                    ~^
[   72s]       |                                                                     |
[   72s]       |                                                                     unsigned int
[   72s]       |                                                                    %lu
[   72s] mv -f commands/appendedsig/.deps-core/appendedsig_module-pkix_asn1_tab.Tpo commands/appendedsig/.deps-core/appendedsig_module-pkix_asn1_tab.Po

```